### PR TITLE
Update run links to DANDI Derivatives destination

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -2,6 +2,7 @@
 const OWNER = "dandi-compute";
 const REPO = "001697";
 const BRANCH = "draft";
+const DERIVATIVES_DANDISET_ID = "001697";
 const CDN_BASE = `https://raw.githubusercontent.com/${OWNER}/${REPO}/${BRANCH}`;
 
 const QUEUE_CDN_BASE = `https://raw.githubusercontent.com/dandi-compute/queue/compressed`;
@@ -1161,12 +1162,13 @@ function treeUrl(filePath) {
 
 /* Build a DANDI derivatives URL for a run capsule path */
 function derivativesUrl(filePath) {
+    const baseUrl = dandiBaseUrl(DERIVATIVES_DANDISET_ID);
     const location = String(filePath ?? "")
         .split("/")
         .filter(Boolean)
         .map(encodeURIComponent)
         .join("/");
-    return `${dandiBaseUrl(REPO)}/dandiset/${REPO}/draft/files?location=${location}&page=1`;
+    return `${baseUrl}/dandiset/${DERIVATIVES_DANDISET_ID}/draft/files?location=${location}&page=1`;
 }
 
 /* Build a Neurosift URL for a DANDI asset (legacy: via DANDI API asset download URL) */
@@ -3486,6 +3488,7 @@ if (typeof module !== "undefined" && module.exports) {
         TEST_DANDISETS,
         DANDISET_SUBJECT_DEFAULTS,
         resolveSubject,
+        derivativesUrl,
         treeUrl,
     };
 }

--- a/src/app.js
+++ b/src/app.js
@@ -869,7 +869,7 @@ function dandiPathDirectoryParts(dandiPath) {
     if (!terminalPart.toLowerCase().endsWith(".nwb")) return pathParts;
     const directoryParts = pathParts.slice(0, -1);
     const nwbStem = terminalPart.slice(0, -4);
-    if (/^sub-[^_]+_ecephys$/i.test(nwbStem)) {
+    if (/^sub-[^_]+_ecephys$/.test(nwbStem)) {
         directoryParts.push(nwbStem);
     }
     return directoryParts;

--- a/src/app.js
+++ b/src/app.js
@@ -2369,9 +2369,14 @@ function renderFlatRunEntry(run) {
             : `<span class="run-sep">·</span><span class="run-bytes">Asset size:&nbsp;${formatByteCount(bytes)}</span>`;
 
     const dandiPath = String(run.dandiPath ?? "").trim();
-    const dandiDirectory = dandiPathDirectoryParts(dandiPath).join("/");
+    const dandiPathParts = String(dandiPath).split("/").filter(Boolean);
+    const terminalPart = dandiPathParts[dandiPathParts.length - 1] ?? "";
+    const dandiDirectoryParts = terminalPart.toLowerCase().endsWith(".nwb")
+        ? dandiPathParts.slice(0, -1)
+        : dandiPathParts;
+    const dandiDirectory = dandiDirectoryParts.join("/");
     const fallbackLocation = run.inSourcedata ? `sourcedata/sub-${run.subject}` : `sub-${run.subject}`;
-    const location = dandiDirectory || fallbackLocation;
+    const location = dandiDirectory ? `${dandiDirectory}/` : fallbackLocation;
     const dandiPathLabel = dandiPath || location;
     const dandiPathUrl = `${dandiBaseUrl(run.dandisetId)}/dandiset/${e(run.dandisetId)}/draft/files?location=${encodeURIComponent(location)}`;
 

--- a/src/app.js
+++ b/src/app.js
@@ -2378,7 +2378,7 @@ function renderFlatRunEntry(run) {
     return `
 <div class="run-entry flat-run-entry ${sc}">
     <div class="run-entry-header flat-run-header">
-        <a class="dandi-view-link" href="${dandiBaseUrl(run.dandisetId)}/dandiset/${e(run.dandisetId)}" target="_blank" rel="noopener">DANDI&nbsp;↖</a>
+        <a class="dandi-view-link" href="${dandiBaseUrl(run.dandisetId)}/dandiset/${e(run.dandisetId)}" target="_blank" rel="noopener">Sourcedata&nbsp;↖</a>
         <span class="status-badge ${sc}">${slbl}</span>
         <span class="flat-run-context">
             <a class="flat-ctx-link" href="${e(neurosiftDandisetUrl(run.dandisetId))}" target="_blank" rel="noopener">Dandiset&nbsp;${e(run.dandisetId)}</a>

--- a/src/app.js
+++ b/src/app.js
@@ -2166,7 +2166,7 @@ function renderDandisetGroup(dandisetId, runs, autoExpand = false) {
             <a class="dandiset-link" href="${e(neurosiftDandisetUrl(dandisetId))}"
                target="_blank" rel="noopener" onclick="event.stopPropagation()">Dandiset&nbsp;${e(dandisetId)}</a>
             <a class="dandi-view-link" href="${dandiBaseUrl(dandisetId)}/dandiset/${e(dandisetId)}"
-               target="_blank" rel="noopener" onclick="event.stopPropagation()">DANDI&nbsp;↖</a>
+               target="_blank" rel="noopener" onclick="event.stopPropagation()">Sourcedata&nbsp;↖</a>
             <span class="group-meta">
                 <span class="group-count">${subjects.length}&nbsp;subject${subjects.length !== 1 ? "s" : ""}</span>
                 <span class="run-sep">·</span>

--- a/src/app.js
+++ b/src/app.js
@@ -1240,7 +1240,7 @@ function renderRunEntry(run) {
         ${run.runDate ? `<span class="run-date">${e(run.runDate)}</span><span class="run-sep">·</span>` : ""}
         ${bytesHtml}
         <span class="run-attempt">Attempt&nbsp;${e(String(run.attempt))}</span>
-        <a class="run-entry-github-link" href="${e(treeUrl(run.path))}" target="_blank" rel="noopener">↗ GitHub</a>
+        <a class="run-entry-github-link" href="${e(treeUrl(run.path))}" target="_blank" rel="noopener">↗ Derivatives</a>
     </div>
 
     ${hasSourceVersions ? renderSourceVersionsSection(run.generatedBy) : ""}

--- a/src/app.js
+++ b/src/app.js
@@ -866,7 +866,13 @@ function dandiPathDirectoryParts(dandiPath) {
         .filter(Boolean);
     if (pathParts.length === 0) return [];
     const terminalPart = pathParts[pathParts.length - 1] ?? "";
-    return terminalPart.toLowerCase().endsWith(".nwb") ? pathParts.slice(0, -1) : pathParts;
+    if (!terminalPart.toLowerCase().endsWith(".nwb")) return pathParts;
+    const directoryParts = pathParts.slice(0, -1);
+    const nwbStem = terminalPart.slice(0, -4);
+    if (/^sub-[^_]+_ecephys$/i.test(nwbStem)) {
+        directoryParts.push(nwbStem);
+    }
+    return directoryParts;
 }
 
 // Build a run directory path from a JSONL queue entry.

--- a/src/app.js
+++ b/src/app.js
@@ -1159,6 +1159,16 @@ function treeUrl(filePath) {
     return `https://github.com/${OWNER}/${REPO}/tree/${BRANCH}/${filePath.split("/").map(encodeURIComponent).join("/")}`;
 }
 
+/* Build a DANDI derivatives URL for a run capsule path */
+function derivativesUrl(filePath) {
+    const location = String(filePath ?? "")
+        .split("/")
+        .filter(Boolean)
+        .map(encodeURIComponent)
+        .join("/");
+    return `${dandiBaseUrl(REPO)}/dandiset/${REPO}/draft/files?location=${location}&page=1`;
+}
+
 /* Build a Neurosift URL for a DANDI asset (legacy: via DANDI API asset download URL) */
 function neurosiftUrl(dandisetId, assetId) {
     const assetDownloadUrl = `${dandiApiBaseUrl(dandisetId)}/api/assets/${assetId}/download/`;
@@ -1240,7 +1250,7 @@ function renderRunEntry(run) {
         ${run.runDate ? `<span class="run-date">${e(run.runDate)}</span><span class="run-sep">·</span>` : ""}
         ${bytesHtml}
         <span class="run-attempt">Attempt&nbsp;${e(String(run.attempt))}</span>
-        <a class="run-entry-github-link" href="${e(treeUrl(run.path))}" target="_blank" rel="noopener">↗ Derivatives</a>
+        <a class="run-entry-derivatives-link" href="${e(derivativesUrl(run.path))}" target="_blank" rel="noopener">↗ Derivatives</a>
     </div>
 
     ${hasSourceVersions ? renderSourceVersionsSection(run.generatedBy) : ""}
@@ -2373,7 +2383,7 @@ function renderFlatRunEntry(run) {
         </span>
         ${bytesHtml}
         <span class="run-attempt">Attempt&nbsp;${e(String(run.attempt))}</span>
-        <a class="run-entry-github-link" href="${e(treeUrl(run.path))}" target="_blank" rel="noopener">↗ GitHub</a>
+        <a class="run-entry-derivatives-link" href="${e(derivativesUrl(run.path))}" target="_blank" rel="noopener">↗ Derivatives</a>
     </div>
 
     ${hasSourceVersions ? renderSourceVersionsSection(run.generatedBy) : ""}

--- a/src/app.unit.test.js
+++ b/src/app.unit.test.js
@@ -899,6 +899,29 @@ describe("treeUrl", () => {
         expect(html).not.toContain("DANDI&nbsp;↖");
     });
 
+    it("renderFlatList links Path to the parent directory of NWB dandi_path", () => {
+        const html = renderFlatList([
+            {
+                status: "success",
+                hasLogs: false,
+                tasks: [],
+                generatedBy: [],
+                vizData: [],
+                dandiPath: "sub-NP06/sub-NP06_ecephys.nwb",
+                inSourcedata: false,
+                subject: "NP06",
+                attempt: 1,
+                path: "derivatives/dandiset-001765/sub-NP06/sub-NP06_ecephys/pipeline-aind+ephys/version-1.2.2+d2b6aef+be2047d_params-e6a0e86_config-0d4bf36_attempt-1",
+                dandisetId: "001765",
+                paramsProfile: "e6a0e86",
+                configHash: "0d4bf36",
+                runDate: "2026-05-24",
+            },
+        ]);
+        expect(html).toContain("location=sub-NP06%2F");
+        expect(html).not.toContain("location=sub-NP06%2Fsub-NP06_ecephys");
+    });
+
     it("builds a GitHub tree URL without session when session is absent", () => {
         const path =
             "derivatives/dandiset-001469/sub-Chronic-Implant-2/pipeline-aind+ephys/version-v1.0.0_params-98fd947_config-6568dda_attempt-1";

--- a/src/app.unit.test.js
+++ b/src/app.unit.test.js
@@ -37,6 +37,7 @@ const {
     sortRuns,
     TEST_DANDISETS,
     DANDISET_SUBJECT_DEFAULTS,
+    derivativesUrl,
     resolveSubject,
     treeUrl,
     uniquePipelineEntries,
@@ -837,6 +838,27 @@ describe("treeUrl", () => {
             "https://github.com/dandi-compute/001697/tree/draft/" +
                 "derivatives/dandiset-000363/sub-480134/ses-20210107T120825/pipeline-aind%2Bephys/version-v1.1.1%2Bb268fd2%2Ba0c5e04_params-4af6a25_config-0d4bf36_attempt-1"
         );
+    });
+
+    describe("derivativesUrl", () => {
+        it("builds a DANDI Archive files URL for a run path with session", () => {
+            const path =
+                "derivatives/dandiset-001849/sourcedata/aind-sample/pipeline-aind+ephys/version-v1.1.1+b268fd2+398f3c4_params-4af6a25_config-0d4bf36_date-2026+05+24_attempt-1";
+            const url = derivativesUrl(path);
+            expect(url).toBe(
+                "https://dandiarchive.org/dandiset/001697/draft/files?location=" +
+                    "derivatives/dandiset-001849/sourcedata/aind-sample/pipeline-aind%2Bephys/" +
+                    "version-v1.1.1%2Bb268fd2%2B398f3c4_params-4af6a25_config-0d4bf36_date-2026%2B05%2B24_attempt-1&page=1"
+            );
+        });
+
+        it("omits leading/trailing slashes in encoded location", () => {
+            const url = derivativesUrl(
+                "/derivatives/dandiset-001470/sub-M536/ses-2025+04+13/pipeline-aind+ephys/version-v1.2.2+d2b6aef+be2047d_params-4af6a25_config-0d4bf36_attempt-1/"
+            );
+            expect(url).toContain("location=derivatives/dandiset-001470/sub-M536/ses-2025%2B04%2B13/");
+            expect(url).toContain("&page=1");
+        });
     });
 
     it("builds a GitHub tree URL without session when session is absent", () => {

--- a/src/app.unit.test.js
+++ b/src/app.unit.test.js
@@ -416,6 +416,21 @@ describe("app unit behavior", () => {
         );
     });
 
+    it("builds run path from single-file ecephys dandi_path with filename stem directory", () => {
+        const path = buildRunPath({
+            dandiset_id: "001765",
+            dandi_path: "sub-NP06/sub-NP06_ecephys.nwb",
+            pipeline: "aind+ephys",
+            version: "1.2.2+d2b6aef+be2047d",
+            params: "e6a0e86",
+            config: "0d4bf36",
+            attempt: 1,
+        });
+        expect(path).toBe(
+            "derivatives/dandiset-001765/sub-NP06/sub-NP06_ecephys/pipeline-aind+ephys/version-1.2.2+d2b6aef+be2047d_params-e6a0e86_config-0d4bf36_attempt-1"
+        );
+    });
+
     it("builds run path from full dandi_path hierarchy when sourcedata segments are present", () => {
         const path = buildRunPath({
             dandiset_id: "001849",

--- a/src/app.unit.test.js
+++ b/src/app.unit.test.js
@@ -876,6 +876,29 @@ describe("treeUrl", () => {
         });
     });
 
+    it("renderFlatList labels the dandiset root link as Sourcedata", () => {
+        const html = renderFlatList([
+            {
+                status: "success",
+                hasLogs: false,
+                tasks: [],
+                generatedBy: [],
+                vizData: [],
+                dandiPath: "sub-NP06/sub-NP06_ecephys.nwb",
+                inSourcedata: false,
+                subject: "NP06",
+                attempt: 1,
+                path: "derivatives/dandiset-001765/sub-NP06/sub-NP06_ecephys/pipeline-aind+ephys/version-1.2.2+d2b6aef+be2047d_params-e6a0e86_config-0d4bf36_attempt-1",
+                dandisetId: "001765",
+                paramsProfile: "e6a0e86",
+                configHash: "0d4bf36",
+                runDate: "2026-05-24",
+            },
+        ]);
+        expect(html).toContain("Sourcedata&nbsp;↖");
+        expect(html).not.toContain("DANDI&nbsp;↖");
+    });
+
     it("builds a GitHub tree URL without session when session is absent", () => {
         const path =
             "derivatives/dandiset-001469/sub-Chronic-Implant-2/pipeline-aind+ephys/version-v1.0.0_params-98fd947_config-6568dda_attempt-1";

--- a/src/styles.css
+++ b/src/styles.css
@@ -1112,7 +1112,7 @@ details[open] > .params-summary::before {
     flex-wrap: wrap;
 }
 
-.run-entry-github-link {
+.run-entry-derivatives-link {
     margin-left: auto;
     font-size: 0.8em;
     color: var(--color-text-secondary);
@@ -1125,7 +1125,7 @@ details[open] > .params-summary::before {
         border-color 0.15s;
     white-space: nowrap;
 }
-.run-entry-github-link:hover {
+.run-entry-derivatives-link:hover {
     color: var(--color-accent);
     border-color: var(--color-accent);
 }


### PR DESCRIPTION
Replaces the run-entry GitHub destination with the DANDI Archive derivatives files destination for the job capsule path.

Also renames the link class from `run-entry-github-link` to `run-entry-derivatives-link` to match the updated purpose, and applies the update consistently across both tree and flat run entry views.

Includes unit test coverage for the new derivatives URL builder behavior.