### PR TITLE
Update GitHub repository link and aria-label text

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -41,11 +41,11 @@
                 title="Switch to light mode"
             ></button>
             <a
-                href="https://github.com/dandi-compute/001697"
+                href="https://github.com/dandi-compute/aind-page"
                 class="site-github-link"
                 target="_blank"
                 rel="noopener"
-                aria-label="View data repository on GitHub"
+                aria-label="View source on GitHub"
             >
                 <svg viewBox="0 0 16 16" aria-hidden="true">
                     <path


### PR DESCRIPTION
## Summary
Updated the GitHub repository link in the header to point to the correct repository and improved the accessibility label for clarity.

## Changes
- Changed GitHub repository URL from `dandi-compute/001697` to `dandi-compute/aind-page`
- Updated aria-label from "View data repository on GitHub" to "View source on GitHub" for better semantic accuracy

## Details
These changes ensure that the GitHub link directs users to the correct source code repository and provides a more accurate description of the link's purpose for screen reader users.

https://claude.ai/code/session_01AQud3Je118PLMZBU7u4Jy5