### PR TITLE
Replace regex-based trailing slash removal with manual loop

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -1772,7 +1772,9 @@ function resolveCodeUrl(codeUrl, version) {
     const isCommitHash = /^[0-9a-f]{6,40}$/i.test(version);
     const alreadySpecific = /\/(commit|tree|blob|releases\/tag)\//i.test(codeUrl);
     if (isCommitHash && !alreadySpecific) {
-        return codeUrl.replace(/\/+$/, "") + "/tree/" + version;
+        let end = codeUrl.length;
+        while (end > 0 && codeUrl.charCodeAt(end - 1) === 47 /* "/" */) end--;
+        return codeUrl.slice(0, end) + "/tree/" + version;
     }
     return codeUrl;
 }


### PR DESCRIPTION
## Summary
Refactored the `resolveCodeUrl` function to replace a regex-based approach for removing trailing slashes with a manual character-by-character loop implementation.

## Key Changes
- Replaced `codeUrl.replace(/\/+$/, "")` with a while loop that manually removes trailing forward slashes by checking character codes
- The new implementation iterates backwards through the string, decrementing an `end` pointer while encountering forward slash characters (charCode 47)
- Uses `codeUrl.slice(0, end)` instead of `replace()` to extract the trimmed portion

## Implementation Details
- The manual loop approach provides more explicit control over trailing slash removal
- Uses character code comparison (`charCodeAt(end - 1) === 47`) instead of regex pattern matching
- Maintains identical functionality while potentially improving performance for strings with multiple trailing slashes

https://claude.ai/code/session_019f1rLJJn7z2HSoxmtC4YVa