### PR TITLE
Make running runs count clickable to filter by status

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -1195,6 +1195,7 @@ function renderSummary(runs) {
     const filter = parseFilter();
     const successHref = narrowUrl({ ...filterNarrowParams(filter, ["failureStep", "status"]), status: "success" });
     const failedHref = narrowUrl({ ...filterNarrowParams(filter, ["status"]), status: "failed" });
+    const runningHref = narrowUrl({ ...filterNarrowParams(filter, ["status"]), status: "running" });
 
     document.getElementById("summary").innerHTML = `
         <div class="summary-stats">
@@ -1202,10 +1203,10 @@ function renderSummary(runs) {
                 <span class="stat-value">${total}</span>
                 <span class="stat-label">Total Runs</span>
             </div>
-            <div class="stat-item stat-running">
+            <a class="stat-item stat-running" href="${e(runningHref)}" title="Show only running runs">
                 <span class="stat-value">${running}</span>
                 <span class="stat-label">Running</span>
-            </div>
+            </a>
             <a class="stat-item stat-success" href="${e(successHref)}" title="Show only successful runs">
                 <span class="stat-value">${success}</span>
                 <span class="stat-label">Successful</span>


### PR DESCRIPTION
## Summary
Made the "Running" stat item in the summary section clickable, allowing users to filter and view only running runs, consistent with the existing behavior for successful and failed runs.

## Changes
- Added `runningHref` variable that generates a filtered URL for running status, following the same pattern as success and failed filters
- Converted the "Running" stat item from a `<div>` to an `<a>` element with the appropriate href and title attributes
- Applied the same styling class (`stat-running`) to maintain visual consistency

## Implementation Details
- The running filter uses `filterNarrowParams()` to preserve existing filters while narrowing by status
- The link includes a descriptive title attribute: "Show only running runs"
- Uses the `e()` function to safely escape the href value, consistent with other stat links

https://claude.ai/code/session_014YtbMh2EUPQ9hwnCi94Fbj