### PR TITLE
Add stalled run detection for jobs running over 24 hours

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -481,9 +481,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -501,9 +498,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -521,9 +515,6 @@
                 "ppc64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -541,9 +532,6 @@
                 "s390x"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -561,9 +549,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -581,9 +566,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [

--- a/src/app.integration.test.js
+++ b/src/app.integration.test.js
@@ -120,6 +120,29 @@ describe("app integration behavior", () => {
         expect(summaryHtml).toContain('<span class="stat-value">0</span>');
     });
 
+    it("shows stalled counter when running runs exceed 24 hours", () => {
+        const oldCreatedAt = new Date(Date.now() - 25 * 60 * 60 * 1000).toISOString();
+        const recentCreatedAt = new Date(Date.now() - 1 * 60 * 60 * 1000).toISOString();
+        renderSummary([
+            { status: "running", createdAt: oldCreatedAt },
+            { status: "running", createdAt: recentCreatedAt },
+        ]);
+
+        const summaryHtml = document.getElementById("summary").innerHTML;
+        expect(summaryHtml).toContain("stat-stalled");
+        expect(summaryHtml).toContain("Stalled");
+        expect(summaryHtml).toContain("⚠ 1");
+    });
+
+    it("hides stalled counter when no running runs exceed 24 hours", () => {
+        const recentCreatedAt = new Date(Date.now() - 1 * 60 * 60 * 1000).toISOString();
+        renderSummary([{ status: "running", createdAt: recentCreatedAt }]);
+
+        const summaryHtml = document.getElementById("summary").innerHTML;
+        expect(summaryHtml).not.toContain("stat-stalled");
+        expect(summaryHtml).not.toContain("Stalled");
+    });
+
     it("formats large byte counts with appropriate decimal units", () => {
         renderSummary([{ status: "success", assetSizeBytes: 2_500_000_000_000 }]);
         expect(document.getElementById("summary").innerHTML).toContain("2.5 TB");

--- a/src/app.integration.test.js
+++ b/src/app.integration.test.js
@@ -132,6 +132,7 @@ describe("app integration behavior", () => {
         expect(summaryHtml).toContain("stat-stalled");
         expect(summaryHtml).toContain("Stalled");
         expect(summaryHtml).toContain("⚠ 1");
+        expect(summaryHtml).toContain('status=stalled');
     });
 
     it("hides stalled counter when no running runs exceed 24 hours", () => {

--- a/src/app.js
+++ b/src/app.js
@@ -208,6 +208,11 @@ function normalizeStatus(status) {
     return status ? String(status).toLowerCase() : null;
 }
 
+function isStalled(run) {
+    if (run.status !== "running" || !run.createdAt) return false;
+    return Date.now() - new Date(run.createdAt).getTime() > 24 * 60 * 60 * 1000;
+}
+
 function applyFilter(runs, filter) {
     const normalizedFilterStatus = normalizeStatus(filter.status);
     return runs.filter((r) => {
@@ -221,8 +226,7 @@ function applyFilter(runs, filter) {
         if (filter.dandiCodebaseVersion && r.codebase !== filter.dandiCodebaseVersion) return false;
         if (filter.assetSize && !matchesAssetSizeExpr(r, filter.assetSize)) return false;
         if (normalizedFilterStatus === "stalled") {
-            const stalledThresholdMs = 24 * 60 * 60 * 1000;
-            if (r.status !== "running" || !r.createdAt || Date.now() - new Date(r.createdAt).getTime() <= stalledThresholdMs) return false;
+            if (!isStalled(r)) return false;
         } else if (normalizedFilterStatus && String(r.status).toLowerCase() !== normalizedFilterStatus) return false;
         if (filter.failureStep) {
             if (!isFailedStatus(r.status)) return false;
@@ -1190,12 +1194,8 @@ function renderSummary(runs) {
     const success = runs.filter((r) => r.status === "success").length;
     const failed = runs.filter((r) => r.status === "failed").length;
     const queued = runs.filter((r) => r.status === "queued").length;
-    const now = Date.now();
-    const stalledThresholdMs = 24 * 60 * 60 * 1000;
     const running = runs.filter((r) => r.status === "running").length;
-    const stalled = runs.filter(
-        (r) => r.status === "running" && r.createdAt && now - new Date(r.createdAt).getTime() > stalledThresholdMs,
-    ).length;
+    const stalled = runs.filter(isStalled).length;
     const partial = runs.filter((r) => r.status === "partial").length;
     const unknown = total - success - failed - queued - running - partial;
     const successfulRuns = runs.filter((run) => run.status === "success");
@@ -1685,30 +1685,35 @@ function neurosiftDandisetUrl(dandisetId) {
 }
 
 function renderRunEntry(run) {
+    const stalled = isStalled(run);
     const sc =
         run.status === "success"
             ? "status-success"
             : run.status === "failed"
               ? "status-failed"
-              : run.status === "running"
-                ? "status-running"
-                : run.status === "queued"
-                  ? "status-queued"
-                  : run.status === "partial"
-                    ? "status-partial"
-                    : "status-unknown";
+              : stalled
+                ? "status-stalled"
+                : run.status === "running"
+                  ? "status-running"
+                  : run.status === "queued"
+                    ? "status-queued"
+                    : run.status === "partial"
+                      ? "status-partial"
+                      : "status-unknown";
     const slbl =
         run.status === "success"
             ? "✓ Success"
             : run.status === "failed"
               ? "✗ Failed"
-              : run.status === "running"
-                ? "▶ Running"
-                : run.status === "queued"
-                  ? "⧗ Queued"
-                  : run.status === "partial"
-                    ? "⚠ Partial"
-                    : "? Unknown";
+              : stalled
+                ? "⚠ Stalled"
+                : run.status === "running"
+                  ? "▶ Running"
+                  : run.status === "queued"
+                    ? "⧗ Queued"
+                    : run.status === "partial"
+                      ? "⚠ Partial"
+                      : "? Unknown";
 
     // Log files present for this run, sourced from the S3 blob map (run.logFiles).
     const { inlineLogs, buttonLogs } = splitRunLogFiles(run);
@@ -3214,30 +3219,35 @@ function renderParamsGroup(paramsProfile, configHash, runs) {
 
 /* ─── Flat view rendering ───────────────────────────────────── */
 function renderFlatRunEntry(run) {
+    const stalled = isStalled(run);
     const sc =
         run.status === "success"
             ? "status-success"
             : run.status === "failed"
               ? "status-failed"
-              : run.status === "running"
-                ? "status-running"
-                : run.status === "queued"
-                  ? "status-queued"
-                  : run.status === "partial"
-                    ? "status-partial"
-                    : "status-unknown";
+              : stalled
+                ? "status-stalled"
+                : run.status === "running"
+                  ? "status-running"
+                  : run.status === "queued"
+                    ? "status-queued"
+                    : run.status === "partial"
+                      ? "status-partial"
+                      : "status-unknown";
     const slbl =
         run.status === "success"
             ? "✓ Success"
             : run.status === "failed"
               ? "✗ Failed"
-              : run.status === "running"
-                ? "▶ Running"
-                : run.status === "queued"
-                  ? "⧗ Queued"
-                  : run.status === "partial"
-                    ? "⚠ Partial"
-                    : "? Unknown";
+              : stalled
+                ? "⚠ Stalled"
+                : run.status === "running"
+                  ? "▶ Running"
+                  : run.status === "queued"
+                    ? "⧗ Queued"
+                    : run.status === "partial"
+                      ? "⚠ Partial"
+                      : "? Unknown";
 
     const { inlineLogs, buttonLogs } = splitRunLogFiles(run);
     const hasLogs = buttonLogs.length > 0;

--- a/src/app.js
+++ b/src/app.js
@@ -220,7 +220,10 @@ function applyFilter(runs, filter) {
         if (filter.dandiCodebaseHash && runDandiCodebaseHash(r) !== filter.dandiCodebaseHash) return false;
         if (filter.dandiCodebaseVersion && r.codebase !== filter.dandiCodebaseVersion) return false;
         if (filter.assetSize && !matchesAssetSizeExpr(r, filter.assetSize)) return false;
-        if (normalizedFilterStatus && String(r.status).toLowerCase() !== normalizedFilterStatus) return false;
+        if (normalizedFilterStatus === "stalled") {
+            const stalledThresholdMs = 24 * 60 * 60 * 1000;
+            if (r.status !== "running" || !r.createdAt || Date.now() - new Date(r.createdAt).getTime() <= stalledThresholdMs) return false;
+        } else if (normalizedFilterStatus && String(r.status).toLowerCase() !== normalizedFilterStatus) return false;
         if (filter.failureStep) {
             if (!isFailedStatus(r.status)) return false;
             const failedStep = r.failureStep;
@@ -265,6 +268,7 @@ const STATUS_LABELS = {
     queued: "Queued",
     running: "Running",
     partial: "Partial",
+    stalled: "Stalled",
 };
 const DECIMAL_DATA_SIZE_UNITS = ["B", "KB", "MB", "GB", "TB", "PB", "EB"];
 const DATA_SIZE_FORMATTER = new Intl.NumberFormat(undefined, { maximumFractionDigits: 2 });
@@ -1201,6 +1205,7 @@ function renderSummary(runs) {
     const successHref = narrowUrl({ ...filterNarrowParams(filter, ["failureStep", "status"]), status: "success" });
     const failedHref = narrowUrl({ ...filterNarrowParams(filter, ["status"]), status: "failed" });
     const runningHref = narrowUrl({ ...filterNarrowParams(filter, ["status"]), status: "running" });
+    const stalledHref = narrowUrl({ ...filterNarrowParams(filter, ["status"]), status: "stalled" });
 
     document.getElementById("summary").innerHTML = `
         <div class="summary-stats">
@@ -1214,10 +1219,10 @@ function renderSummary(runs) {
             </a>
             ${
                 stalled
-                    ? `<div class="stat-item stat-stalled" title="Running jobs that have been running for more than 24 hours">
+                    ? `<a class="stat-item stat-stalled" href="${e(stalledHref)}" title="Show only stalled runs (running for more than 24 hours)">
                 <span class="stat-value">⚠ ${stalled}</span>
                 <span class="stat-label">Stalled</span>
-            </div>`
+            </a>`
                     : ""
             }
             <a class="stat-item stat-success" href="${e(successHref)}" title="Show only successful runs">

--- a/src/app.js
+++ b/src/app.js
@@ -1186,7 +1186,12 @@ function renderSummary(runs) {
     const success = runs.filter((r) => r.status === "success").length;
     const failed = runs.filter((r) => r.status === "failed").length;
     const queued = runs.filter((r) => r.status === "queued").length;
+    const now = Date.now();
+    const stalledThresholdMs = 24 * 60 * 60 * 1000;
     const running = runs.filter((r) => r.status === "running").length;
+    const stalled = runs.filter(
+        (r) => r.status === "running" && r.createdAt && now - new Date(r.createdAt).getTime() > stalledThresholdMs,
+    ).length;
     const partial = runs.filter((r) => r.status === "partial").length;
     const unknown = total - success - failed - queued - running - partial;
     const successfulRuns = runs.filter((run) => run.status === "success");
@@ -1207,6 +1212,14 @@ function renderSummary(runs) {
                 <span class="stat-value">${running}</span>
                 <span class="stat-label">Running</span>
             </a>
+            ${
+                stalled
+                    ? `<div class="stat-item stat-stalled" title="Running jobs that have been running for more than 24 hours">
+                <span class="stat-value">⚠ ${stalled}</span>
+                <span class="stat-label">Stalled</span>
+            </div>`
+                    : ""
+            }
             <a class="stat-item stat-success" href="${e(successHref)}" title="Show only successful runs">
                 <span class="stat-value">${success}</span>
                 <span class="stat-label">Successful</span>

--- a/src/styles.css
+++ b/src/styles.css
@@ -20,6 +20,8 @@
     --color-queued-bg: rgba(83, 168, 182, 0.1);
     --color-running: #9b7fde;
     --color-running-bg: rgba(155, 127, 222, 0.1);
+    --color-stalled: #e07b3a;
+    --color-stalled-bg: rgba(224, 123, 58, 0.1);
     --font-main: "Source Sans 3", -apple-system, sans-serif;
     --radius: 6px;
 }
@@ -40,6 +42,7 @@
     --color-partial-bg: rgba(224, 168, 58, 0.08);
     --color-queued-bg: rgba(83, 168, 182, 0.08);
     --color-running-bg: rgba(155, 127, 222, 0.08);
+    --color-stalled-bg: rgba(224, 123, 58, 0.08);
 }
 
 *,
@@ -603,6 +606,9 @@ a.qp-asset-link:hover {
 }
 .stat-partial .stat-value {
     color: var(--color-partial);
+}
+.stat-stalled .stat-value {
+    color: var(--color-stalled);
 }
 
 /* ─── Run card ──────────────────────────────────────────────── */

--- a/src/styles.css
+++ b/src/styles.css
@@ -631,6 +631,9 @@ a.qp-asset-link:hover {
 .run-card.status-partial {
     border-left-color: var(--color-partial);
 }
+.run-card.status-stalled {
+    border-left-color: var(--color-stalled);
+}
 
 .run-header {
     display: flex;
@@ -668,6 +671,10 @@ a.qp-asset-link:hover {
 .status-badge.status-running {
     background: var(--color-running-bg);
     color: var(--color-running);
+}
+.status-badge.status-stalled {
+    background: var(--color-stalled-bg);
+    color: var(--color-stalled);
 }
 .status-badge.status-partial {
     background: var(--color-partial-bg);
@@ -1458,6 +1465,9 @@ details[open] > .params-summary::before {
 }
 .run-entry.status-partial {
     border-left-color: var(--color-partial);
+}
+.run-entry.status-stalled {
+    border-left-color: var(--color-stalled);
 }
 
 .run-entry-header {


### PR DESCRIPTION
## Summary
This PR adds detection and visualization of "stalled" runs—jobs that have been in a running state for more than 24 hours. A new stalled counter is displayed in the summary section when such runs are detected.

## Key Changes
- **Detection Logic**: Added stalled run calculation in `renderSummary()` that identifies running jobs exceeding the 24-hour threshold
- **UI Display**: Conditionally renders a stalled counter badge with warning icon (⚠) in the summary section when stalled runs exist
- **Styling**: Added new CSS variables and styles for the stalled state with an orange/amber color scheme (`#e07b3a`)
- **Tests**: Added two integration tests to verify stalled counter appears when appropriate and is hidden when no stalled runs exist

## Implementation Details
- Stalled runs are calculated by comparing the current time against each running job's `createdAt` timestamp
- The stalled counter only displays when `stalled > 0`, keeping the UI clean when there are no issues
- The stalled badge includes a tooltip explaining it represents "Running jobs that have been running for more than 24 hours"
- Color scheme uses orange to distinguish stalled runs from other statuses and provide visual warning

https://claude.ai/code/session_01Grffqi4yknVZzJdDYM51bE