### PR TITLE
Update pipeline repository owner to AllenNeuralDynamics

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -15,15 +15,15 @@ const QUEUE_CONFIG_SOURCE_URL = "https://github.com/dandi-compute/queue/blob/mai
 
 const GITHUB_API_BASE = `https://api.github.com/repos/${OWNER}/${REPO}`;
 
-const PIPELINE_REPO_URL = "https://github.com/CodyCBakerPhD/aind-ephys-pipeline";
-const PIPELINE_API_BASE = "https://api.github.com/repos/CodyCBakerPhD/aind-ephys-pipeline";
+const PIPELINE_REPO_URL = "https://github.com/AllenNeuralDynamics/aind-ephys-pipeline";
+const PIPELINE_API_BASE = "https://api.github.com/repos/AllenNeuralDynamics/aind-ephys-pipeline";
 const CODE_REPO_URL = "https://github.com/dandi-compute/code";
 const AIND_EPHYS_PIPELINE_CODE_URL =
     "https://github.com/dandi-compute/code/blob/main/src/dandi_compute_code/aind_ephys_pipeline";
 const PARAMS_SCHEMA_URL =
-    "https://raw.githubusercontent.com/CodyCBakerPhD/aind-ephys-pipeline/main/pipeline/default_params_schema.json";
+    "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-ephys-pipeline/main/pipeline/default_params_schema.json";
 const PARAMS_PLACEHOLDER_URL =
-    "https://raw.githubusercontent.com/CodyCBakerPhD/aind-ephys-pipeline/main/pipeline/default_params.json";
+    "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-ephys-pipeline/main/pipeline/default_params.json";
 const REGISTRY_FALLBACK_ALIAS_PRIORITY = 1;
 const MIN_SHORT_COMMIT_HASH_LENGTH = 6;
 const FULL_COMMIT_HASH_LENGTH = 40;
@@ -4390,13 +4390,13 @@ async function init() {
     if (_viewMode === "compare") {
         setPageCopy(
             "AIND Pipeline Diffs Index",
-            'Assembled comparison links for the <a href="https://github.com/CodyCBakerPhD/aind-ephys-pipeline" target="_blank" rel="noopener">pipeline repository</a> and registered parameter or configuration definitions.'
+            'Assembled comparison links for the <a href="https://github.com/AllenNeuralDynamics/aind-ephys-pipeline" target="_blank" rel="noopener">pipeline repository</a> and registered parameter or configuration definitions.'
         );
     }
     if (_viewMode === "params") {
         setPageCopy(
             "Register New Params File",
-            'Create a custom parameter file for the <a href="https://github.com/CodyCBakerPhD/aind-ephys-pipeline" target="_blank" rel="noopener">AIND Ephys Pipeline</a> and submit it for use in the compute pipeline.'
+            'Create a custom parameter file for the <a href="https://github.com/AllenNeuralDynamics/aind-ephys-pipeline" target="_blank" rel="noopener">AIND Ephys Pipeline</a> and submit it for use in the compute pipeline.'
         );
     }
     if (_viewMode === "archive") {

--- a/src/app.unit.test.js
+++ b/src/app.unit.test.js
@@ -1939,7 +1939,7 @@ describe("diff page helpers", () => {
                     baseVersion: "v1.0.1+20abeb6",
                     headVersion: "v1.1.1+b268fd2+5d20fd2",
                     compareUrl:
-                        "https://github.com/CodyCBakerPhD/aind-ephys-pipeline/compare/20abeb66850ec6ce0127c1489c22bd949d9bb642...b268fd207886905b40a956e7f6a839884ce9835f",
+                        "https://github.com/AllenNeuralDynamics/aind-ephys-pipeline/compare/20abeb66850ec6ce0127c1489c22bd949d9bb642...b268fd207886905b40a956e7f6a839884ce9835f",
                     modalHtml: expect.stringContaining("Pipeline version"),
                 },
             ]);


### PR DESCRIPTION
## Summary
This PR updates all references to the AIND ephys pipeline repository from the personal account `CodyCBakerPhD` to the organizational account `AllenNeuralDynamics`.

## Key Changes
- Updated `PIPELINE_REPO_URL` constant to point to `AllenNeuralDynamics/aind-ephys-pipeline`
- Updated `PIPELINE_API_BASE` constant to use the new organizational repository
- Updated `PARAMS_SCHEMA_URL` to reference the new repository location
- Updated `PARAMS_PLACEHOLDER_URL` to reference the new repository location
- Updated page copy links in the `init()` function to point to the new repository
- Updated test expectations to reflect the new repository URL in comparison links

## Implementation Details
All changes are straightforward URL updates replacing `CodyCBakerPhD` with `AllenNeuralDynamics` across configuration constants, API endpoints, and user-facing links. This ensures the application consistently references the pipeline from the official organizational repository.

https://claude.ai/code/session_01UhaWUPnVGnvJBiXPdHfBHD