### PR TITLE
Potential fix for code scanning alert no. 3: Client-side cross-site scripting

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -54,7 +54,9 @@ let _sortDirection = "desc";
 let _filteredRuns = [];
 
 function parseViewMode() {
-    return new URLSearchParams(window.location.search).get("view") ?? null;
+    const rawView = new URLSearchParams(window.location.search).get("view");
+    const allowedViews = new Set(["compare", "params", "tests", "archive"]);
+    return allowedViews.has(rawView) ? rawView : null;
 }
 
 function syncTopNav(viewMode = parseViewMode()) {


### PR DESCRIPTION
Potential fix for [https://github.com/dandi-compute/aind-page/security/code-scanning/3](https://github.com/dandi-compute/aind-page/security/code-scanning/3)

General fix: never interpolate untrusted input directly into HTML strings assigned to `innerHTML`; either (1) build DOM nodes with safe APIs (`createElement`, `textContent`, `setAttribute`) or (2) strictly validate/normalize input to an allowlist and/or HTML-escape before interpolation.

Best minimal fix here without changing behavior: normalize `view` to the known allowlisted modes in `parseViewMode()`. This keeps existing rendering approach intact while ensuring `_viewMode` can never contain attacker-controlled HTML-breaking payloads. Since the app already uses fixed view modes, this preserves functionality and removes tainted data before it reaches line 545.

Change needed in `src/app.js`:
- Edit `parseViewMode()` (lines 56–58 region) to:
  - read raw `view`;
  - return only one of `compare | params | tests | archive`;
  - otherwise return `null`.

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
