### PR TITLE
Implement immutable blob caching and optimize registry loading

### DIFF
--- a/.claude/skills/run-dashboard/SKILL.md
+++ b/.claude/skills/run-dashboard/SKILL.md
@@ -1,12 +1,12 @@
 ---
-name: verify
-description: Build, launch, and drive this static dashboard in a real browser to verify changes end-to-end. Use when confirming a change to src/app.js works in the running app, not just in vitest.
+name: run-dashboard
+description: Launch and drive this static dashboard in a real browser with stubbed external data. Use when running or screenshotting the app locally, or when verifying that a change to src/app.js works in the running app (not just in vitest).
 ---
 
-# Verifying aind-page changes in a running browser
+# Running and driving the aind-page dashboard in a browser
 
 The app is a static page (`src/index.html` + `src/app.js`, no build step). All data
-comes from external hosts fetched client-side, so verification = serve `src/`,
+comes from external hosts fetched client-side, so running it locally = serve `src/`,
 open it in Chromium, and stub the external endpoints at the network boundary.
 
 ## Recipe

--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: verify
+description: Build, launch, and drive this static dashboard in a real browser to verify changes end-to-end. Use when confirming a change to src/app.js works in the running app, not just in vitest.
+---
+
+# Verifying aind-page changes in a running browser
+
+The app is a static page (`src/index.html` + `src/app.js`, no build step). All data
+comes from external hosts fetched client-side, so verification = serve `src/`,
+open it in Chromium, and stub the external endpoints at the network boundary.
+
+## Recipe
+
+1. Serve the page: any static server over `src/` (e.g. `python3 -m http.server 8123 -d src`,
+   or a small Node `http` server). `localhost` is a secure context, so the Cache API works.
+2. Drive with Playwright against the preinstalled browser (do NOT `playwright install`):
+   - `npm i playwright-core` in a scratch dir.
+   - `chromium.launchPersistentContext(profileDir, { headless: true, executablePath: "/opt/pw-browsers/chromium_headless_shell-1194/chrome-linux/headless_shell" })`
+     (adjust the revision dir to what's in `/opt/pw-browsers/`). A persistent
+     profile lets you simulate a browser restart (close + relaunch, same dir)
+     to test cross-session persistence (Cache API, localStorage).
+3. Stub external hosts with `page.route(/raw\.githubusercontent\.com|dandiarchive\.s3\.amazonaws\.com|api\.github\.com/, handler)`
+   and `route.fulfill(...)`. Endpoints the queue dashboard hits:
+   - `.../queue/compressed/state.jsonl.gz` — gzip JSONL (`zlib.gzipSync` of newline-joined entries).
+   - `.../queue/main/archive_state.jsonl` — plain JSONL (archive view).
+   - `.../queue/main/queue_config.json` — priorities banner.
+   - `.../code/main/...registered_params.json` / `registered_configs.json` — registries.
+   - `https://dandiarchive.s3.amazonaws.com/blobs/<3>/<3>/<id>` — per-run artifacts
+     (trace.txt, dataset_description.json, quality_control.json, visualization_output.json).
+4. Load `http://localhost:8123/?view=dashboard` and wait for `#summary .summary-stats`;
+   run cards are `.run-entry`. Count/inspect stubbed requests in the route handler
+   to assert network behavior (e.g. blob requests are cache-hits on reload).
+
+## Fixture gotchas (cost real debugging time)
+
+- The queue view is `?view=dashboard` — `view=main` silently falls back to the landing page.
+- A JSONL entry's blob lookups go through `run.path` built by `buildRunPath(entry)`
+  from `dandiset_id`/`subject`/`pipeline`/`version`/`params`/`config`/`attempt`.
+  The keys in `output_paths` MUST match that computed path exactly
+  (`derivatives/dandiset-<id>/sub-<subject>/pipeline-<pipeline>/version-<version>_params-<params>_config-<config>_attempt-<n>/...`)
+  or every artifact resolves to null and nothing is fetched.
+- `dataset_description.json` is only fetched when the entry has a
+  `dataset_description_path` field (`{ "<repo-path>": "<blob-id>" }` map), not
+  merely a matching `output_paths` key.
+- Fulfilled ETags on cross-origin fetches aren't exposed to page JS without
+  `Access-Control-Expose-Headers: ETag`, so If-None-Match assertions against
+  stubs need that header (the real GitHub CDN sends it).
+- The Google Fonts request fails offline — harmless, ignore it.
+
+A complete working example of this recipe (server + stubs + phased
+cold/reload/restart/refresh assertions) was used for the blob-cache overhaul;
+its shape is worth copying for future network-behavior checks.

--- a/src/app.js
+++ b/src/app.js
@@ -664,6 +664,10 @@ const SUN_ICON = `<svg viewBox="0 0 20 20" aria-hidden="true"><circle cx="10" cy
 const ETAG_CACHE_PREFIX = "aind_etag:";
 
 async function cachedFetch(url, init = {}) {
+    // Content-addressed S3 blobs are immutable: a cache hit never needs
+    // revalidation, so skip the conditional-GET machinery entirely.
+    if (isImmutableBlobUrl(url)) return blobCachedFetch(url, init);
+
     const cacheKey = ETAG_CACHE_PREFIX + url;
     let cached = null;
     try {
@@ -702,6 +706,114 @@ async function cachedFetch(url, init = {}) {
     }
 
     return new Response(body, { status: resp.status, headers: { "Content-Type": contentType } });
+}
+
+/* ─── Immutable S3 blob cache ───────────────────────────────── */
+// DANDI S3 blob URLs are content-addressed (the blob id is a content hash), so
+// the body behind a given URL can never change — a re-run surfaces as new blob
+// ids in the queue state. Cached blobs therefore never need revalidation and
+// are stored persistently in the Cache API (large quota, shared across
+// tabs/sessions), with the sessionStorage ETag-cache format as a fallback for
+// contexts without CacheStorage. A per-page memory Map sits on top so repeat
+// loads in the same tab (e.g. the manual queue refresh) skip storage entirely.
+// Every cache operation is best-effort: failures fall through to the network.
+const BLOB_CACHE_NAME = "aind-blobs-v1";
+const BLOB_MEMORY_CACHE_MAX_BODY = 512 * 1024; // keep huge bodies out of the Map
+const _blobMemoryCache = new Map(); // url -> { body, contentType, status }
+
+function isImmutableBlobUrl(url) {
+    return typeof url === "string" && url.startsWith(`${S3_BLOB_BASE}/`);
+}
+
+async function openBlobCache() {
+    if (typeof caches === "undefined") return null;
+    try {
+        return await caches.open(BLOB_CACHE_NAME);
+    } catch {
+        return null; // insecure context or storage restrictions
+    }
+}
+
+// Drop persistent blob caches left behind by older cache-name versions.
+function pruneStaleBlobCaches() {
+    if (typeof caches === "undefined") return;
+    caches
+        .keys()
+        .then((names) =>
+            Promise.all(
+                names
+                    .filter((name) => name.startsWith("aind-blobs-") && name !== BLOB_CACHE_NAME)
+                    .map((name) => caches.delete(name))
+            )
+        )
+        .catch(() => {});
+}
+
+function blobResponse({ body, contentType, status }) {
+    return new Response(body, { status: status ?? 200, headers: { "Content-Type": contentType ?? "" } });
+}
+
+async function readCachedBlob(url) {
+    const memoryHit = _blobMemoryCache.get(url);
+    if (memoryHit) return blobResponse(memoryHit);
+
+    const cache = await openBlobCache();
+    if (cache) {
+        try {
+            const match = await cache.match(url);
+            if (match) {
+                const entry = {
+                    body: await match.text(),
+                    contentType: match.headers.get("Content-Type") ?? "",
+                    status: match.status,
+                };
+                if (entry.body.length <= BLOB_MEMORY_CACHE_MAX_BODY) _blobMemoryCache.set(url, entry);
+                return blobResponse(entry);
+            }
+        } catch {
+            /* fall through to the sessionStorage fallback */
+        }
+    }
+
+    try {
+        const raw = sessionStorage.getItem(ETAG_CACHE_PREFIX + url);
+        if (raw) return blobResponse(JSON.parse(raw));
+    } catch {
+        /* sessionStorage unavailable or parse error */
+    }
+    return null;
+}
+
+function writeCachedBlob(url, body, contentType, status) {
+    const entry = { body, contentType, status };
+    if (body.length <= BLOB_MEMORY_CACHE_MAX_BODY) _blobMemoryCache.set(url, entry);
+
+    if (typeof caches !== "undefined") {
+        openBlobCache()
+            .then((cache) => cache?.put(url, blobResponse(entry)))
+            .catch(() => {});
+        return;
+    }
+    // No CacheStorage: fall back to the sessionStorage ETag-cache format so the
+    // entry is still readable by readCachedBlob (no etag → no revalidation).
+    try {
+        sessionStorage.setItem(ETAG_CACHE_PREFIX + url, JSON.stringify(entry));
+    } catch {
+        /* Ignore storage errors (e.g., quota exceeded) */
+    }
+}
+
+async function blobCachedFetch(url, init = {}) {
+    const hit = await readCachedBlob(url);
+    if (hit) return hit;
+
+    const resp = await fetch(url, init); // plain GET: no If-None-Match needed
+    if (!resp.ok) return resp; // never cache failures
+
+    const body = await resp.text();
+    const contentType = resp.headers.get("Content-Type") ?? "";
+    writeCachedBlob(url, body, contentType, resp.status);
+    return blobResponse({ body, contentType, status: resp.status });
 }
 
 function normalizeRegistryEntries(registryEntries) {
@@ -750,6 +862,17 @@ async function loadAindPipelineRegistries() {
         console.warn(configResult.reason?.message ?? "Failed to load config registry.");
     }
     return { paramsRegistry: PARAMS_REGISTRY, configRegistry: CONFIG_REGISTRY };
+}
+
+// Memoized registry load so init() and loadQueueData() can share one in-flight
+// fetch; kicked off without await so it overlaps the queue-state/blob fetches.
+// loadAindPipelineRegistries never rejects (it warns and falls back to raw
+// values), so awaiting this promise cannot introduce a new failure mode.
+let _registriesReady = null;
+
+function ensureRegistriesLoaded() {
+    if (!_registriesReady) _registriesReady = loadAindPipelineRegistries();
+    return _registriesReady;
 }
 
 /* ─── Data fetching ─────────────────────────────────────────── */
@@ -1302,7 +1425,7 @@ function renderSummary(runs) {
    key/value view. Dandiset-id entries link into the filtered dashboard.       */
 async function fetchQueueConfig() {
     try {
-        const resp = await fetch(QUEUE_CONFIG_URL, { cache: "no-cache" });
+        const resp = await cachedFetch(QUEUE_CONFIG_URL);
         if (!resp.ok) return null;
         return await resp.json();
     } catch {
@@ -3395,6 +3518,9 @@ function initLayoutToggle() {
         }
         const refreshBtn = ev.target.closest("[data-refresh-queue]");
         if (!refreshBtn) return;
+        // Only the queue/archive state caches are cleared: per-run S3 blobs are
+        // content-addressed (immutable), so new results always arrive as new
+        // blob URLs in the freshly fetched state.
         clearQueueStateCache();
         loadQueueData();
     });
@@ -4357,6 +4483,9 @@ async function loadQueueData() {
     renderFilterBanner(parseFilter(), []);
 
     try {
+        // Registries are only consumed at filter/render time, so let their
+        // fetch overlap the queue-state download and the per-run blob fan-out.
+        const registriesReady = ensureRegistriesLoaded();
         const entries = _viewMode === "archive" ? await fetchArchiveState() : await fetchQueueState();
         const runs = parseQueueEntries(entries);
 
@@ -4416,6 +4545,10 @@ async function loadQueueData() {
                 };
             })
         );
+
+        // Params/config alias resolution (filtering, registry links) needs the
+        // registries from here on.
+        await registriesReady;
 
         const sortedRuns = sortRuns(runsWithStatus, parseSortMode());
 
@@ -4512,11 +4645,12 @@ async function init() {
     }
 
     showLoading();
-    if (_viewMode !== "params") {
-        await loadAindPipelineRegistries();
-    }
+    pruneStaleBlobCaches();
     if (_viewMode === "compare") {
         try {
+            // The compare page consumes the registries up front (params/config
+            // entries), unlike the queue views which overlap the fetch.
+            await ensureRegistriesLoaded();
             const entries = await fetchQueueState();
             const runs = parseQueueEntries(entries);
             const pipelineEntries = await buildPipelineCompareEntries(runs);
@@ -4569,9 +4703,13 @@ if (typeof module !== "undefined" && module.exports) {
     module.exports = {
         applyFilter,
         buildRunPath,
+        cachedFetch,
         classifyFailedTaskStep,
         clearQueueStateCache,
+        ensureRegistriesLoaded,
+        fetchQueueConfig,
         fetchQueueState,
+        isImmutableBlobUrl,
         fetchArchiveState,
         archiveStateCacheKey,
         fetchSlurmLogs,

--- a/src/app.unit.test.js
+++ b/src/app.unit.test.js
@@ -3,11 +3,15 @@ const {
     buildRunPath,
     buildPipelineDiffPairs,
     buildParamsCompareEntries,
+    cachedFetch,
     classifyFailedTaskStep,
     clearQueueStateCache,
     collectJsonDiffs,
     collectTextDiffs,
+    ensureRegistriesLoaded,
+    fetchQueueConfig,
     fetchQueueState,
+    isImmutableBlobUrl,
     fetchArchiveState,
     archiveStateCacheKey,
     fetchSlurmLogs,
@@ -2820,5 +2824,204 @@ describe("clearQueueStateCache", () => {
         clearQueueStateCache();
         expect(sessionStorage.getItem(QUEUE_STATE_CACHE_KEY)).toBeNull();
         expect(sessionStorage.getItem("other-key")).toBe("other-value");
+    });
+});
+
+describe("cachedFetch immutable blob cache", () => {
+    // Each test uses a unique blob id so the module-level in-memory blob cache
+    // never leaks state between tests.
+    let blobCounter = 0;
+    function uniqueBlobUrl() {
+        const id = `abcdef${String(blobCounter++).padStart(34, "0")}`;
+        return `https://dandiarchive.s3.amazonaws.com/blobs/${id.slice(0, 3)}/${id.slice(3, 6)}/${id}`;
+    }
+
+    let originalFetch;
+
+    beforeEach(() => {
+        sessionStorage.clear();
+        originalFetch = global.fetch;
+    });
+
+    afterEach(() => {
+        global.fetch = originalFetch;
+        delete global.caches;
+        sessionStorage.clear();
+    });
+
+    it("recognizes S3 blob URLs as immutable", () => {
+        expect(isImmutableBlobUrl("https://dandiarchive.s3.amazonaws.com/blobs/abc/def/abcdef123")).toBe(true);
+        expect(isImmutableBlobUrl("https://raw.githubusercontent.com/dandi-compute/code/main/x.json")).toBe(false);
+        expect(isImmutableBlobUrl(null)).toBe(false);
+    });
+
+    it("fetches a blob once and serves repeat requests from cache without network", async () => {
+        const url = uniqueBlobUrl();
+        global.fetch = vi
+            .fn()
+            .mockResolvedValue(new Response("blob-body", { status: 200, headers: { "Content-Type": "text/plain" } }));
+
+        const first = await cachedFetch(url);
+        expect(await first.text()).toBe("blob-body");
+        expect(global.fetch).toHaveBeenCalledTimes(1);
+        // Plain GET: no If-None-Match revalidation header on blob requests.
+        const init = global.fetch.mock.calls[0][1];
+        expect(init?.headers?.get?.("If-None-Match") ?? null).toBeNull();
+
+        const second = await cachedFetch(url);
+        expect(await second.text()).toBe("blob-body");
+        expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it("serves a blob from a pre-existing sessionStorage entry without any fetch", async () => {
+        const url = uniqueBlobUrl();
+        sessionStorage.setItem(
+            "aind_etag:" + url,
+            JSON.stringify({ etag: '"v1"', body: "warm-body", contentType: "text/plain", status: 200 })
+        );
+        global.fetch = vi.fn();
+
+        const resp = await cachedFetch(url);
+
+        expect(await resp.text()).toBe("warm-body");
+        expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it("still revalidates non-blob URLs with If-None-Match", async () => {
+        const url = "https://raw.githubusercontent.com/dandi-compute/code/main/some.json";
+        sessionStorage.setItem(
+            "aind_etag:" + url,
+            JSON.stringify({ etag: '"v1"', body: '{"a":1}', contentType: "application/json", status: 200 })
+        );
+        global.fetch = vi.fn().mockResolvedValue(new Response(null, { status: 304 }));
+
+        const resp = await cachedFetch(url);
+
+        expect(await resp.json()).toEqual({ a: 1 });
+        expect(global.fetch).toHaveBeenCalledTimes(1);
+        const [, init] = global.fetch.mock.calls[0];
+        expect(init.headers.get("If-None-Match")).toBe('"v1"');
+    });
+
+    it("stores fetched blobs in the Cache API when available", async () => {
+        const url = uniqueBlobUrl();
+        const fakeCache = { match: vi.fn().mockResolvedValue(undefined), put: vi.fn().mockResolvedValue(undefined) };
+        global.caches = { open: vi.fn().mockResolvedValue(fakeCache) };
+        global.fetch = vi.fn().mockResolvedValue(new Response("api-body", { status: 200 }));
+
+        const resp = await cachedFetch(url);
+        expect(await resp.text()).toBe("api-body");
+
+        // The Cache API write is fire-and-forget; allow it to settle.
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        expect(fakeCache.put).toHaveBeenCalledTimes(1);
+        expect(fakeCache.put.mock.calls[0][0]).toBe(url);
+        // Cache API path is used instead of sessionStorage.
+        expect(sessionStorage.getItem("aind_etag:" + url)).toBeNull();
+    });
+
+    it("serves a blob from the Cache API without any fetch", async () => {
+        const url = uniqueBlobUrl();
+        const cachedResp = new Response("cached-api-body", {
+            status: 200,
+            headers: { "Content-Type": "text/plain" },
+        });
+        const fakeCache = { match: vi.fn().mockResolvedValue(cachedResp), put: vi.fn() };
+        global.caches = { open: vi.fn().mockResolvedValue(fakeCache) };
+        global.fetch = vi.fn();
+
+        const resp = await cachedFetch(url);
+
+        expect(await resp.text()).toBe("cached-api-body");
+        expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it("falls back to the network when Cache API operations fail", async () => {
+        const url = uniqueBlobUrl();
+        global.caches = { open: vi.fn().mockRejectedValue(new Error("denied")) };
+        global.fetch = vi.fn().mockResolvedValue(new Response("net-body", { status: 200 }));
+
+        const resp = await cachedFetch(url);
+        expect(await resp.text()).toBe("net-body");
+
+        const url2 = uniqueBlobUrl();
+        global.caches = {
+            open: vi.fn().mockResolvedValue({ match: vi.fn().mockRejectedValue(new Error("boom")), put: vi.fn() }),
+        };
+        global.fetch = vi.fn().mockResolvedValue(new Response("net-body-2", { status: 200 }));
+        const resp2 = await cachedFetch(url2);
+        expect(await resp2.text()).toBe("net-body-2");
+    });
+
+    it("returns non-ok blob responses as-is without caching them", async () => {
+        const url = uniqueBlobUrl();
+        global.fetch = vi
+            .fn()
+            .mockResolvedValueOnce(new Response(null, { status: 404 }))
+            .mockResolvedValueOnce(new Response("late-body", { status: 200 }));
+
+        const first = await cachedFetch(url);
+        expect(first.ok).toBe(false);
+        expect(first.status).toBe(404);
+
+        const second = await cachedFetch(url);
+        expect(await second.text()).toBe("late-body");
+        expect(global.fetch).toHaveBeenCalledTimes(2);
+    });
+});
+
+describe("fetchQueueConfig", () => {
+    let originalFetch;
+
+    beforeEach(() => {
+        sessionStorage.clear();
+        originalFetch = global.fetch;
+    });
+
+    afterEach(() => {
+        global.fetch = originalFetch;
+        sessionStorage.clear();
+    });
+
+    it("fetches and parses the queue config through cachedFetch (no cache: no-cache opt-out)", async () => {
+        global.fetch = vi.fn().mockResolvedValue(
+            new Response(JSON.stringify({ priorities: ["000409"] }), {
+                status: 200,
+                headers: { "Content-Type": "application/json", ETag: '"cfg-v1"' },
+            })
+        );
+
+        const config = await fetchQueueConfig();
+
+        expect(config).toEqual({ priorities: ["000409"] });
+        const [url, init] = global.fetch.mock.calls[0];
+        expect(init.cache).toBeUndefined();
+        // ETag-cached like other mutable sources, enabling 304 revalidation.
+        expect(JSON.parse(sessionStorage.getItem("aind_etag:" + url)).etag).toBe('"cfg-v1"');
+    });
+
+    it("returns null on fetch failure", async () => {
+        global.fetch = vi.fn().mockRejectedValue(new Error("network down"));
+        expect(await fetchQueueConfig()).toBeNull();
+    });
+});
+
+describe("ensureRegistriesLoaded", () => {
+    it("memoizes the registry load across concurrent callers", async () => {
+        const originalFetch = global.fetch;
+        global.fetch = vi
+            .fn()
+            .mockResolvedValue(new Response(JSON.stringify(REGISTERED_PARAMS_FIXTURE), { status: 200 }));
+        try {
+            const [first, second] = await Promise.all([ensureRegistriesLoaded(), ensureRegistriesLoaded()]);
+            expect(first).toBe(second);
+            // One params + one config fetch in total, not per caller.
+            expect(global.fetch.mock.calls.length).toBeLessThanOrEqual(2);
+
+            await ensureRegistriesLoaded();
+            expect(global.fetch.mock.calls.length).toBeLessThanOrEqual(2);
+        } finally {
+            global.fetch = originalFetch;
+        }
     });
 });


### PR DESCRIPTION
## Summary

This PR adds intelligent caching for immutable S3 blobs and optimizes registry loading to overlap with other network requests. The changes improve performance by eliminating redundant fetches and revalidation for content-addressed artifacts.

## Key Changes

- **Immutable blob caching**: Implemented a three-tier cache for DANDI S3 blobs (memory → Cache API → sessionStorage fallback) that recognizes content-addressed URLs never change and skips conditional-GET revalidation entirely
  - Added `isImmutableBlobUrl()` to identify S3 blob URLs
  - Added `blobCachedFetch()` with dedicated blob cache logic separate from mutable-resource ETag caching
  - Blobs are stored persistently in the Cache API with a fallback to sessionStorage for contexts without CacheStorage
  - Memory cache prevents repeated storage lookups for blobs accessed multiple times in the same session

- **Registry loading optimization**: Converted `loadAindPipelineRegistries()` to a memoized `ensureRegistriesLoaded()` function that allows concurrent callers to share a single in-flight fetch
  - Registry fetch now overlaps with queue-state and blob downloads instead of blocking on it
  - Eliminates redundant registry fetches across page initialization and data refresh

- **Queue config caching**: Changed `fetchQueueConfig()` to use `cachedFetch()` instead of `fetch(..., { cache: "no-cache" })`, enabling ETag-based revalidation for the mutable config resource

- **Cache cleanup**: Added `pruneStaleBlobCaches()` to remove stale blob cache versions on initialization

- **Test coverage**: Added comprehensive test suite for blob caching behavior, registry memoization, and queue config fetching

## Implementation Details

- Blob cache respects a 512KB threshold for memory storage to avoid keeping huge bodies in the Map
- All cache operations are best-effort; failures gracefully fall through to the network
- Non-ok responses (4xx, 5xx) are never cached, allowing retry on subsequent requests
- The queue refresh button only clears mutable state caches (queue/archive), not blob caches, since new results arrive as new blob URLs
- Added verification skill documentation for end-to-end testing in a real browser with stubbed endpoints

https://claude.ai/code/session_01JxavrXQEkb7t6RgocAxDru