### PR TITLE
Fix double counting of stalled runs in running status

### DIFF
--- a/src/app.integration.test.js
+++ b/src/app.integration.test.js
@@ -144,6 +144,23 @@ describe("app integration behavior", () => {
         expect(summaryHtml).toContain("status=stalled");
     });
 
+    it("does not double count stalled runs as running", () => {
+        const stalledCreatedAt = new Date(Date.now() - 25 * 60 * 60 * 1000).toISOString();
+        const recentCreatedAt = new Date(Date.now() - 1 * 60 * 60 * 1000).toISOString();
+        renderSummary([
+            { status: "running", createdAt: stalledCreatedAt },
+            { status: "running", createdAt: stalledCreatedAt },
+            { status: "running", createdAt: recentCreatedAt },
+        ]);
+
+        const summary = document.getElementById("summary");
+        const runningValue = summary.querySelector(".stat-running .stat-value").textContent;
+        const stalledValue = summary.querySelector(".stat-stalled .stat-value").textContent;
+        expect(runningValue).toBe("1");
+        expect(stalledValue).toBe("⚠ 2");
+        expect(summary.innerHTML).not.toContain("Unknown");
+    });
+
     it("hides stalled counter when no running runs exceed 24 hours", () => {
         const recentCreatedAt = new Date(Date.now() - 1 * 60 * 60 * 1000).toISOString();
         renderSummary([{ status: "running", createdAt: recentCreatedAt }]);

--- a/src/app.js
+++ b/src/app.js
@@ -297,6 +297,8 @@ function applyFilter(runs, filter) {
         if (filter.assetSize && !matchesAssetSizeExpr(r, filter.assetSize)) return false;
         if (normalizedFilterStatus === "stalled") {
             if (!isStalled(r)) return false;
+        } else if (normalizedFilterStatus === "running") {
+            if (String(r.status).toLowerCase() !== "running" || isStalled(r)) return false;
         } else if (normalizedFilterStatus && String(r.status).toLowerCase() !== normalizedFilterStatus) return false;
         if (filter.failureStep) {
             if (!isFailedStatus(r.status)) return false;
@@ -1402,9 +1404,9 @@ function renderSummary(runs) {
     const success = runs.filter((r) => r.status === "success").length;
     const failed = runs.filter((r) => r.status === "failed").length;
     const queued = runs.filter((r) => r.status === "queued").length;
-    const running = runs.filter((r) => r.status === "running").length;
     const stalled = runs.filter(isStalled).length;
-    const unknown = total - success - failed - queued - running;
+    const running = runs.filter((r) => r.status === "running" && !isStalled(r)).length;
+    const unknown = total - success - failed - queued - running - stalled;
     const successfulRuns = runs.filter((run) => run.status === "success");
     const runsWithKnownByteCounts = successfulRuns.filter((run) => runByteCount(run) !== null).length;
     const totalBytes = sumRunByteCounts(successfulRuns);

--- a/src/app.unit.test.js
+++ b/src/app.unit.test.js
@@ -349,6 +349,18 @@ describe("app unit behavior", () => {
         expect(applyFilter(runs, { status: "running" })).toEqual([{ status: "running", id: 4 }]);
     });
 
+    it("excludes stalled runs from the running status filter", () => {
+        const stalledCreatedAt = new Date(Date.now() - 25 * 60 * 60 * 1000).toISOString();
+        const recentCreatedAt = new Date(Date.now() - 1 * 60 * 60 * 1000).toISOString();
+        const runs = [
+            { status: "running", createdAt: stalledCreatedAt, id: 1 },
+            { status: "running", createdAt: recentCreatedAt, id: 2 },
+        ];
+
+        expect(applyFilter(runs, { status: "running" })).toEqual([runs[1]]);
+        expect(applyFilter(runs, { status: "stalled" })).toEqual([runs[0]]);
+    });
+
     it("filters runs by params/config types and dandi codebase hash", async () => {
         await loadFixtureRegistries();
         const runs = [


### PR DESCRIPTION
## Summary
Fixed a bug where runs that have been stalled (running for more than 24 hours) were being counted in both the "running" and "stalled" counters, causing incorrect status summaries and filter results.

## Key Changes
- **Filter logic**: Updated `applyFilter()` to exclude stalled runs when filtering by "running" status, ensuring stalled runs are only counted in the "stalled" category
- **Summary counts**: Modified `renderSummary()` to exclude stalled runs from the running count calculation and properly account for stalled runs in the unknown count
- **Test coverage**: Added integration and unit tests to verify that stalled runs are not double-counted and that filtering works correctly for both "running" and "stalled" statuses

## Implementation Details
- Stalled runs are identified using the existing `isStalled()` function (runs with status "running" created more than 24 hours ago)
- The fix ensures that a run with status "running" that is older than 24 hours is treated as "stalled" rather than "running" in all counting and filtering operations
- The summary calculation now properly accounts for all run states: success, failed, queued, running (recent only), stalled, and unknown

https://claude.ai/code/session_01HxxZVmw47HwsSWaSutXToH