### PR TITLE
Soft-reset in-memory caches on in-page filter changes

### DIFF
--- a/src/app.integration.test.js
+++ b/src/app.integration.test.js
@@ -1,8 +1,11 @@
 const {
+    blobMemoryCacheStats,
     cancelHydration,
+    getRunsInScope,
     hydrationIdle,
     initFlatShowMore,
     initHydrationPromotion,
+    initInPageFilterNavigation,
     loadQueueData,
     parseQueueEntries,
     queueStateCacheKey,
@@ -12,6 +15,7 @@ const {
     showError,
     showLoading,
     showResults,
+    softResetForFilterChange,
 } = require("./app");
 
 beforeEach(() => {
@@ -887,5 +891,187 @@ describe("progressive queue loading", () => {
         staleTrace.resolve(new Response(TRACE_FAILED_PRE, { status: 200 }));
         await new Promise((r) => setTimeout(r, 0));
         expect(document.querySelector("#runs .run-entry").className).toContain("status-success");
+    });
+
+    describe("soft reset on in-page filter changes", () => {
+        // Two-dandiset fixture: run A (000777) succeeds, run B (000888) fails
+        // in pre-processing and carries every card-detail artifact.
+        function seedTwoDandisets({ layout = "tree" } = {}) {
+            window.history.replaceState(null, "", layout === "flat" ? "/?layout=flat" : "/");
+            const a = withArtifacts(makeEntry({ dandiset_id: "000777" }), { trace: newBlobId() });
+            const b = withArtifacts(makeEntry({ dandiset_id: "000888" }), {
+                trace: newBlobId(),
+                dd: newBlobId(),
+                viz: newBlobId(),
+                qc: newBlobId(),
+                png: newBlobId(),
+            });
+            seedQueueState([a.entry, b.entry]);
+            installFetch(
+                new Map([
+                    [a.urls.trace, () => new Response(TRACE_OK, { status: 200 })],
+                    [b.urls.trace, () => new Response(TRACE_FAILED_PRE, { status: 200 })],
+                    [b.urls.dd, () => new Response('{"GeneratedBy":[]}', { status: 200 })],
+                    [b.urls.viz, () => new Response("{}", { status: 200 })],
+                    [b.urls.qc, () => new Response('{"metrics":[{"name":"drift","stage":"pre"}]}', { status: 200 })],
+                ])
+            );
+            initHydrationPromotion();
+            initInPageFilterNavigation();
+            return { a, b };
+        }
+
+        it("applies summary-stat filter links in place and clears the blob memory cache", async () => {
+            seedTwoDandisets();
+            await loadQueueData();
+            await hydrationIdle();
+            expect(blobMemoryCacheStats().entries).toBeGreaterThan(0);
+
+            const failedLink = document.querySelector("#summary a.stat-failed");
+            failedLink.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+
+            // Applied via pushState, no navigation: URL carries the filter and
+            // the page re-rendered synchronously for the narrowed scope.
+            expect(window.location.search).toContain("status=failed");
+            expect(blobMemoryCacheStats()).toEqual({ entries: 0, bytes: 0 });
+            expect(document.getElementById("filter-banner").innerHTML).toContain("Filtered view:");
+            expect(document.querySelector("#summary .stat-value").textContent).toBe("1"); // Total Runs
+            await hydrationIdle();
+
+            // Back returns to the unfiltered view in place as well.
+            window.history.replaceState(null, "", "/");
+            window.dispatchEvent(new Event("popstate"));
+            expect(document.querySelector("#summary .stat-value").textContent).toBe("2");
+            await hydrationIdle();
+        });
+
+        it("drops payloads and flags of runs leaving the filtered set, keeps settled statuses, and re-hydrates", async () => {
+            const { b } = seedTwoDandisets({ layout: "flat" });
+            await loadQueueData();
+            await hydrationIdle();
+
+            // Reveal run B's card so its detail + QC artifacts hydrate.
+            const card = Array.from(document.querySelectorAll("[data-run-key]")).find(
+                (el) => el.dataset.runKey === b.path
+            );
+            const section = card.querySelector("details");
+            section.open = true;
+            section.dispatchEvent(new Event("toggle"));
+            await hydrationIdle();
+
+            const runB = getRunsInScope().find((run) => run.dandisetId === "000888");
+            const runA = getRunsInScope().find((run) => run.dandisetId === "000777");
+            expect(runB.qualityControl).not.toBeNull();
+            expect(runB.detailsLoaded).toBe(true);
+            expect(runB.tasks.length).toBeGreaterThan(0);
+
+            // Narrow to dandiset 000777: B leaves the filtered set.
+            window.history.replaceState(null, "", "/?layout=flat&dandiset=000777");
+            softResetForFilterChange();
+
+            // B's hydrated payloads are dropped and its flags reset so a later
+            // reveal re-fetches (from the persistent cache)…
+            expect(runB.tasks).toEqual([]);
+            expect(runB.datasetDescription).toBeNull();
+            expect(runB.qualityControl).toBeNull();
+            expect(runB.vizLinks).toBeNull();
+            expect(runB.detailsLoaded).toBe(false);
+            expect(runB.detailQueued).toBe(false);
+            expect(runB.qcLoaded).toBe(false);
+            expect(runB.qcQueued).toBe(false);
+            expect(runB.traceLoaded).toBe(false);
+            // …while its settled status stays truthful without a refetch.
+            expect(runB.status).toBe("failed");
+            expect(runB.failureStep).toBe("pre-processing");
+            expect(runB.statusProvisional).toBe(false);
+
+            // A stays fully hydrated: still in scope, nothing re-enqueued.
+            expect(runA.traceLoaded).toBe(true);
+            expect(runA.status).toBe("success");
+            expect(runA.tasks.length).toBeGreaterThan(0);
+            expect(document.querySelectorAll("#runs .run-entry")).toHaveLength(1);
+
+            // B's status is already settled, so background hydration must NOT
+            // re-read its trace while it stays out of scope — that would
+            // repopulate the memory just reclaimed.
+            await hydrationIdle();
+            expect(runB.traceLoaded).toBe(false);
+            expect(runB.tasks).toEqual([]);
+
+            // Broadening the filter brings B back into the visible set, and
+            // the restarted hydration re-reads its trace (from the persistent
+            // cache) so its task table returns.
+            window.history.replaceState(null, "", "/?layout=flat");
+            softResetForFilterChange();
+            await hydrationIdle();
+            expect(runB.traceLoaded).toBe(true);
+            expect(runB.tasks.length).toBeGreaterThan(0);
+        });
+
+        it("keeps hydrating never-settled out-of-scope runs so hydration-dependent filters converge", async () => {
+            window.history.replaceState(null, "", "/");
+            const a = withArtifacts(makeEntry({ dandiset_id: "000777" }), { trace: newBlobId() });
+            const b = withArtifacts(makeEntry({ dandiset_id: "000888", has_output: false }), { trace: newBlobId() });
+            seedQueueState([a.entry, b.entry]);
+            const gatedTrace = deferred();
+            installFetch(
+                new Map([
+                    [a.urls.trace, () => new Response(TRACE_OK, { status: 200 })],
+                    // Fresh Response per call: the superseded generation and the
+                    // restarted one both read this URL.
+                    [b.urls.trace, () => gatedTrace.promise.then((body) => new Response(body, { status: 200 }))],
+                ])
+            );
+            initInPageFilterNavigation();
+
+            await loadQueueData();
+
+            // Filter to pre-processing failures while B's trace is still in
+            // flight: nothing matches yet, and B's status is unsettled.
+            window.history.replaceState(null, "", "/?failureStep=pre-processing");
+            softResetForFilterChange();
+            expect(document.getElementById("error").innerHTML).toContain("No pipeline runs match");
+
+            // B stayed in the restarted hydration queue; when its trace lands
+            // it enters the filtered set via flushHydrationUpdates.
+            gatedTrace.resolve(TRACE_FAILED_PRE);
+            await hydrationIdle();
+            expect(document.getElementById("error").style.display).toBe("none");
+            expect(document.querySelector("#runs .run-entry, details.dandiset-group")).not.toBeNull();
+            const runB = getRunsInScope().find((run) => run.dandisetId === "000888");
+            expect(runB.status).toBe("failed");
+            expect(runB.failureStep).toBe("pre-processing");
+        });
+
+        it("applies the filter form in place via the Apply submit path", async () => {
+            seedTwoDandisets();
+            await loadQueueData();
+            await hydrationIdle();
+
+            const form = document.querySelector(".filter-form");
+            form.querySelector('input[name="dandiset"]').value = "000888";
+            form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+
+            expect(window.location.search).toContain("dandiset=000888");
+            expect(document.querySelector("#summary .stat-value").textContent).toBe("1");
+            expect(document.querySelector("#summary .stat-failed .stat-value").textContent.trim()).toBe("1");
+            await hydrationIdle();
+        });
+
+        it("leaves view switches to real navigation", async () => {
+            seedTwoDandisets();
+            await loadQueueData();
+            await hydrationIdle();
+
+            const link = document.createElement("a");
+            link.href = "?view=archive";
+            document.getElementById("runs").append(link);
+            const evt = new MouseEvent("click", { bubbles: true, cancelable: true });
+            link.dispatchEvent(evt);
+
+            // Not intercepted: the browser would navigate (jsdom just no-ops).
+            expect(evt.defaultPrevented).toBe(false);
+            expect(window.location.search).not.toContain("view=archive");
+        });
     });
 });

--- a/src/app.integration.test.js
+++ b/src/app.integration.test.js
@@ -840,6 +840,45 @@ describe("progressive queue loading", () => {
         expect(cards[0].className).toContain("status-failed");
     });
 
+    it("releases a group's materialized body when it closes and rebuilds it on reopen", async () => {
+        const handlers = new Map();
+        const entries = [];
+        for (let i = 0; i < 3; i++) {
+            const { entry, urls } = withArtifacts(makeEntry({ subject: `sub${i}` }), { trace: newBlobId() });
+            entries.push(entry);
+            handlers.set(urls.trace, () => new Response(TRACE_FAILED_PRE, { status: 200 }));
+        }
+        seedQueueState(entries);
+        installFetch(handlers);
+        initHydrationPromotion();
+
+        await loadQueueData();
+        await hydrationIdle();
+
+        const subject = document.querySelector("details.subject-group");
+        subject.open = true;
+        subject.dispatchEvent(new Event("toggle"));
+        const session = subject.querySelector("details.session-group");
+        session.open = true;
+        session.dispatchEvent(new Event("toggle"));
+        expect(document.querySelectorAll(".run-entry")).toHaveLength(1);
+
+        // Closing the subject group reclaims its card DOM immediately (it used
+        // to linger until the next full re-render).
+        subject.open = false;
+        subject.dispatchEvent(new Event("toggle"));
+        expect(subject.dataset.bodyRendered).toBeUndefined();
+        expect(document.querySelectorAll(".run-entry")).toHaveLength(0);
+
+        // Reopening rebuilds the body from the live run objects — with the
+        // still-open session group's expansion state restored.
+        subject.open = true;
+        subject.dispatchEvent(new Event("toggle"));
+        const cards = document.querySelectorAll(".run-entry");
+        expect(cards).toHaveLength(1);
+        expect(cards[0].className).toContain("status-failed");
+    });
+
     it("materializes flat-layout cards in chunks behind a Show more button", async () => {
         window.history.replaceState(null, "", "/?layout=flat");
         const entries = [];

--- a/src/app.js
+++ b/src/app.js
@@ -4950,6 +4950,21 @@ function runsForGroupKey(groupKey) {
     return sortRuns(_filteredRuns).filter((run) => runGroupKeys(run).includes(groupKey));
 }
 
+// Reclaim a closed tree group's materialized body. Bodies used to linger
+// until the next full re-render; over a long browsing session the accumulated
+// cards — and the decoded images their <img> elements keep alive — dominate
+// the tab's memory, so drop them eagerly. Reopening rebuilds the body from
+// the live (possibly further-hydrated) run objects via renderLazyGroupBody,
+// exactly like a first open; descendant groups keep their _openGroupKeys
+// entries, so their expansion state is restored by that rebuild.
+function releaseGroupBody(details) {
+    if (!details.dataset.bodyRendered) return;
+    const body = details.querySelector(":scope > [data-group-body]");
+    if (!body) return;
+    delete details.dataset.bodyRendered;
+    body.innerHTML = "";
+}
+
 // Build a lazily deferred group body on first open. No-op for groups whose
 // body was already rendered (data-body-rendered) or non-tree groups.
 function renderLazyGroupBody(details) {
@@ -4980,11 +4995,13 @@ function initHydrationPromotion() {
             if (!(details instanceof Element)) return;
             const groupKey = details.dataset?.groupKey;
             if (groupKey) {
-                // Track expansion state for lazy re-renders; a group closing
-                // needs no further work (its body stays until a full re-render
-                // reclaims it).
+                // Track expansion state for lazy re-renders. A closing group
+                // releases its materialized body immediately so a long
+                // open-browse-close session doesn't accumulate card DOM (and
+                // pinned images) for groups no longer on screen.
                 if (!details.open) {
                     _openGroupKeys.delete(groupKey);
+                    releaseGroupBody(details);
                     return;
                 }
                 _openGroupKeys.add(groupKey);

--- a/src/app.js
+++ b/src/app.js
@@ -73,10 +73,11 @@ let _openGroupKeys = new Set();
 const FLAT_RENDER_CHUNK = 200;
 let _flatRenderLimit = FLAT_RENDER_CHUNK;
 
+const ALLOWED_VIEW_MODES = new Set(["dashboard", "compare", "params", "tests", "archive"]);
+
 function parseViewMode() {
     const rawView = new URLSearchParams(window.location.search).get("view");
-    const allowedViews = new Set(["dashboard", "compare", "params", "tests", "archive"]);
-    return allowedViews.has(rawView) ? rawView : null;
+    return ALLOWED_VIEW_MODES.has(rawView) ? rawView : null;
 }
 
 function syncTopNav(viewMode = parseViewMode()) {
@@ -290,6 +291,10 @@ function buildInitialRun(run) {
         qualityControl: null,
         logFiles: runLogFiles(run),
         traceLoaded: !run.hasLogs, // nothing to fetch for runs without logs
+        // Whether a trace has confirmed status/failureStep at least once.
+        // Unlike traceLoaded this survives the filter-change soft reset, so a
+        // released run's badges stay truthful without a background refetch.
+        statusSettled: !run.hasLogs,
         detailsLoaded: false,
         detailQueued: false,
         qcLoaded: false,
@@ -822,6 +827,19 @@ function blobMemoryCachePut(url, entry) {
         _blobMemoryCache.delete(oldUrl);
         _blobMemoryCacheBytes -= oldEntry.body.length;
     }
+}
+
+// Release every retained blob body (used by the filter-change soft reset).
+// Only the in-memory layer is dropped: the persistent Cache API store (or its
+// sessionStorage fallback) keeps the bytes, so later reads are disk hits.
+function clearBlobMemoryCache() {
+    _blobMemoryCache.clear();
+    _blobMemoryCacheBytes = 0;
+}
+
+// Test hook: current retained-entry count and byte total of the memory layer.
+function blobMemoryCacheStats() {
+    return { entries: _blobMemoryCache.size, bytes: _blobMemoryCacheBytes };
 }
 
 function isImmutableBlobUrl(url) {
@@ -4853,6 +4871,7 @@ async function hydrateRunStatus(run) {
         failureStep,
         statusProvisional: false,
         traceLoaded: true,
+        statusSettled: true,
     });
 }
 
@@ -5128,6 +5147,194 @@ function flushHydrationUpdates() {
     if (!banner || !banner.contains(document.activeElement)) renderFilterBanner(filter, _runsInScope);
 }
 
+/* ─── In-page filter changes + memory soft reset ────────────── */
+// Filter changes historically navigated (the filter form is a plain GET form;
+// crumbs, clear links, summary stats, and narrow links are plain anchors), so
+// every change rebuilt the page from scratch. Same-view filter navigations are
+// instead applied in place via history.pushState: the queue state is already in
+// memory, so the new scope renders instantly — and the switch doubles as a
+// "soft reset" that reclaims what a long-lived tab accumulated for the old
+// scope (retained blob bodies, hydrated card payloads, materialized DOM).
+//
+// The soft reset never touches the durable layers: the Cache API blob store
+// (content-addressed, immutable), the sessionStorage queue-state ETag cache,
+// and the params/config registries all survive, so everything dropped here
+// re-reads from disk instead of the network when needed again.
+//
+// View switches (?view=...) still navigate for real — they load a different
+// page type — as does anything cross-origin, cross-path, or targeted.
+
+// JSON snapshot of the parseFilter() set the rendered queue reflects. Null
+// until a queue load succeeds, which keeps in-page interception off on the
+// landing/compare/params pages and after a failed load.
+let _activeFilterKey = null;
+let _inPageFilterNavInit = false;
+
+function filterStateKey(filter = parseFilter()) {
+    // A GET submit of the filter form serializes untouched inputs as empty
+    // params; applyFilter/isFilterActive treat "" and absent alike, so the
+    // snapshot must too.
+    return JSON.stringify(filter, (key, value) => (value === "" ? null : value));
+}
+
+// Test hook: the live run objects backing the current load.
+function getRunsInScope() {
+    return _runsInScope;
+}
+
+// Drop everything hydration attached to a run, resetting it to its
+// buildInitialRun shape except for the settled status fields: status,
+// failureStep, statusProvisional, and statusSettled survive so badges and
+// summary stats stay truthful without a refetch. The cleared queueing flags
+// make the run re-fetch once it matters again (re-entering the filtered set,
+// or a card reveal) — cheaply, via the persistent blob cache.
+function releaseRunHydration(run) {
+    run.tasks = [];
+    run.generatedBy = [];
+    run.datasetDescription = null;
+    run.vizData = run.hasOutput ? fetchVisualizationData(run) : null;
+    run.vizLinks = null;
+    run.qualityControl = null;
+    run.traceLoaded = !run.hasLogs;
+    run.detailsLoaded = false;
+    run.detailQueued = false;
+    run.qcLoaded = false;
+    run.qcQueued = false;
+}
+
+// Re-render the already-loaded queue for the filter set in the current URL,
+// reclaiming memory held for the previous scope.
+function softResetForFilterChange() {
+    const filter = parseFilter();
+    _activeFilterKey = filterStateKey(filter);
+
+    // Supersede in-flight hydration before mutating scope (existing generation
+    // bump — stale results must never touch the re-rendered DOM).
+    cancelHydration();
+    clearBlobMemoryCache();
+
+    const isFiltered = isFilterActive(filter);
+    const filteredRuns = applyFilter(sortRuns(_runsInScope), filter);
+    const keep = new Set(filteredRuns);
+    for (const run of _runsInScope) {
+        if (!keep.has(run)) releaseRunHydration(run);
+    }
+    _filteredRuns = filteredRuns;
+
+    // Collapse the tree and reset flat-layout chunking, exactly like a fresh
+    // load: the old scope's materialized group bodies are reclaimed with the
+    // re-render.
+    _openGroupKeys = new Set();
+    _flatRenderLimit = FLAT_RENDER_CHUNK;
+
+    if (isFiltered && filteredRuns.length === 0) {
+        // Possibly transient: the restarted hydration below may yet bring runs
+        // into the filtered set (see the matching branch in loadQueueData).
+        showError("No pipeline runs match the current filter.");
+        document.getElementById("summary").style.display = "none";
+        document.getElementById("runs").style.display = "none";
+    } else {
+        renderSummary(isFiltered ? filteredRuns : _runsInScope);
+        document.getElementById("runs").innerHTML =
+            _layoutMode === "flat" ? renderFlatList(filteredRuns) : renderDandisets(sortRuns(filteredRuns));
+        initInlineHtmlFrames();
+        initLayoutToggle();
+        document.getElementById("error").style.display = "none";
+        showResults();
+    }
+    renderFilterBanner(filter, _runsInScope);
+    window.scrollTo(0, 0);
+
+    // Restart hydration for the new scope, visible runs first (same ordering
+    // as loadQueueData). Out-of-scope runs whose status a trace already
+    // settled are deliberately NOT re-enqueued: re-reading their traces would
+    // repopulate the tasks arrays and the memory cache just dropped, and
+    // their retained status/failureStep already keeps the summary and filter
+    // membership truthful. They re-hydrate when a later filter change brings
+    // them back into the visible set. Never-settled runs stay queued so
+    // hydration-dependent filters keep converging via flushHydrationUpdates —
+    // and a codebase-hash filter hydrates the whole scope, since membership
+    // needs every run's provenance (see needsEagerDetails in startHydration).
+    const rest = _runsInScope.filter((run) => !keep.has(run));
+    const backgroundRuns = filter.dandiCodebaseHash ? rest : rest.filter((run) => !run.statusSettled);
+    startHydration([...filteredRuns, ...backgroundRuns]);
+}
+
+// Apply the current URL to the loaded queue without a navigation. In-page URLs
+// built by narrowUrl embed the live layout/sort values, so normally only the
+// filter set differs — but popstate can restore an entry carrying older
+// layout/sort params, so those re-sync too.
+function handleInPageFilterUrlChange() {
+    const layoutChanged =
+        _layoutMode !== parseLayoutMode() || _sortMode !== parseSortMode() || _sortDirection !== parseSortDirection();
+    _layoutMode = parseLayoutMode();
+    _sortMode = parseSortMode();
+    _sortDirection = parseSortDirection();
+    if (filterStateKey() !== _activeFilterKey) {
+        softResetForFilterChange();
+    } else if (layoutChanged) {
+        initLayoutToggle();
+        rerenderRuns();
+    }
+}
+
+// Whether a URL can be applied in place: same origin and path, no fragment,
+// and staying on the view the page rendered (view switches load a different
+// page type and keep navigating for real).
+function isInPageFilterUrl(url) {
+    if (url.origin !== window.location.origin || url.pathname !== window.location.pathname || url.hash) return false;
+    const rawView = new URLSearchParams(url.search).get("view");
+    return (ALLOWED_VIEW_MODES.has(rawView) ? rawView : null) === _viewMode;
+}
+
+function initInPageFilterNavigation() {
+    if (_inPageFilterNavInit) return;
+    _inPageFilterNavInit = true;
+
+    // Filter links (crumbs, clear links, summary stats, narrow links, priority
+    // chips) — delegated so links from every re-render are covered, and in the
+    // capture phase because the ⊕ Narrow links inside group summaries stop
+    // propagation inline (to keep the click from toggling their group), which
+    // would never let a bubble listener see them. Modified clicks (new tab,
+    // download) keep their native behavior.
+    document.addEventListener(
+        "click",
+        (evt) => {
+            if (_activeFilterKey === null || evt.defaultPrevented) return;
+            if (evt.button !== 0 || evt.metaKey || evt.ctrlKey || evt.shiftKey || evt.altKey) return;
+            if (!(evt.target instanceof Element)) return;
+            const anchor = evt.target.closest("a[href]");
+            if (!anchor || anchor.hasAttribute("download")) return;
+            if (anchor.target && anchor.target !== "_self") return;
+            const url = new URL(anchor.getAttribute("href"), window.location.href);
+            if (!isInPageFilterUrl(url)) return;
+            evt.preventDefault();
+            window.history.pushState(null, "", `${url.pathname}${url.search}`);
+            handleInPageFilterUrlChange();
+        },
+        true
+    );
+
+    // The filter form (Apply / Enter in an input). Mirrors the native GET
+    // serialization so the resulting URL matches what a full-page submit would
+    // have produced.
+    document.addEventListener("submit", (evt) => {
+        if (_activeFilterKey === null || evt.defaultPrevented) return;
+        const form = evt.target;
+        if (!(form instanceof Element) || !form.classList.contains("filter-form")) return;
+        const qs = new URLSearchParams(new FormData(form)).toString();
+        evt.preventDefault();
+        window.history.pushState(null, "", `${window.location.pathname}${qs ? `?${qs}` : ""}`);
+        handleInPageFilterUrlChange();
+    });
+
+    // Back/forward across pushState entries stays in-page too.
+    window.addEventListener("popstate", () => {
+        if (_activeFilterKey === null) return;
+        handleInPageFilterUrlChange();
+    });
+}
+
 /* ─── Queue data loader ─────────────────────────────────────── */
 // Fetches, processes, and renders the queue state for the current view.
 // Only applies to the dashboard queue views ("main", "tests", and "archive");
@@ -5140,6 +5347,9 @@ async function loadQueueData() {
     // Supersede any in-flight hydration from a previous load before the new
     // state fetch begins (stale results must never touch the fresh DOM).
     cancelHydration();
+    // In-page filter application stays off until this load succeeds (the
+    // in-memory scope it would re-render is about to be replaced).
+    _activeFilterKey = null;
     // Fresh load: collapse the tree and reset flat-layout chunking, matching
     // the pre-lazy-rendering behavior of a full reload.
     _openGroupKeys = new Set();
@@ -5188,6 +5398,7 @@ async function loadQueueData() {
 
         _runsInScope = runsInScope;
         _filteredRuns = filteredRuns;
+        _activeFilterKey = filterStateKey(filter);
         _layoutMode = parseLayoutMode();
         _sortMode = parseSortMode();
         _sortDirection = parseSortDirection();
@@ -5231,6 +5442,7 @@ async function init() {
     initModal();
     initHydrationPromotion();
     initFlatShowMore();
+    initInPageFilterNavigation();
     syncTopNav(_viewMode);
 
     // The landing page is the default view (no `view` param). It has no queue
@@ -5321,10 +5533,15 @@ document.addEventListener("DOMContentLoaded", init);
 if (typeof module !== "undefined" && module.exports) {
     module.exports = {
         applyFilter,
+        blobMemoryCacheStats,
         buildInitialRun,
         buildRunPath,
         cachedFetch,
         cancelHydration,
+        clearBlobMemoryCache,
+        getRunsInScope,
+        initInPageFilterNavigation,
+        softResetForFilterChange,
         classifyFailedTaskStep,
         clearQueueStateCache,
         deriveFlagStatus,


### PR DESCRIPTION
## Summary

Implements a memory "soft reset" whenever the active filter set changes, so a long-lived dashboard tab reclaims what it accumulated for the previous scope — and, as the enabler, converts same-view filter changes from full-page navigations into in-page `history.pushState` updates (which also makes filtering feel instant, since the queue state is already in memory). A follow-up commit also releases closed tree-group bodies immediately, so viz-heavy browsing sessions stop accumulating card DOM even when no filter changes.

## Investigation: how filters applied before this PR

As instructed, I traced every filter path first. **All of them were full navigations** — no in-page filter path existed:

- The **Apply** button submits the filter banner's plain `method="get"` form (no submit handler anywhere).
- **Filter crumbs**, per-input **clear** links, **"× View all runs"**, **summary-stat** links (`renderSummary`), **⊕ Narrow** links in group headers, and **queue-priority chips** are all plain `<a href>` anchors built by `narrowUrl()`.
- `history.replaceState` was used only for `layout`/`sort`/`sortDir` sync (which never creates history entries), and there was no `popstate` handler — so no same-document history traversal existed either.

Since a navigation already resets all JS memory, the soft reset would have been dead code as-is. The task explicitly allowed converting paths ("plus any you convert"), so this PR intercepts exactly the **same-view filter navigations** (same origin + path + `view` param) — the form submit, all `narrowUrl`-built anchors, and back/forward via a `popstate` handler. View switches (`?view=...`), cross-origin/targeted links, and modified clicks (Ctrl/Cmd/middle-click, `target="_blank"`, `download`) keep navigating for real. Interception is armed only after a successful queue load (`_activeFilterKey`), so the landing/compare/params pages and failed loads are untouched. One subtlety: the ⊕ Narrow links call `event.stopPropagation()` inline (to avoid toggling their group), so the delegated click listener runs in the capture phase.

## The soft reset (`softResetForFilterChange`)

On any in-page filter-set change (compared via normalized `parseFilter()` snapshots):

1. `cancelHydration()` — the existing generation bump, unchanged; a wedged fetch from the old scope can never block or touch the new one.
2. The in-memory blob LRU (`_blobMemoryCache` + byte counter) is cleared. The persistent Cache API store (`aind-blobs-v1`) is **never** touched, so re-reads are disk hits.
3. Runs **outside** the new filtered set drop their hydrated payloads (`tasks`, `datasetDescription`, `qualityControl`, `vizLinks`, and the QC-partitioned `vizData`) and reset `traceLoaded`/`detailsLoaded`/`detailQueued`/`qcLoaded`/`qcQueued`, so a later reveal re-fetches from the disk cache. `status`/`failureStep`/`statusProvisional` survive — badges, summary stats, and filter membership stay truthful with no refetch.
4. `_openGroupKeys`/`_flatRenderLimit` reset, the list re-renders (reclaiming the old scope's materialized group bodies), and `startHydration()` restarts for the new scope, visible runs first.
5. Never cleared: Cache API blob store, sessionStorage queue-state ETag cache, registries.

**One deliberate refinement over the letter of the spec:** restarting hydration over the *full* scope re-reads every released trace from disk and immediately repopulates the `tasks` arrays and the memory cache — my first browser measurement showed a net heap delta of ~0 because of exactly this. So runs carry a new `statusSettled` marker (set once a trace confirms them; survives release), and settled out-of-scope runs are *not* re-enqueued in the background. They re-hydrate when a filter change brings them back into the visible set. Never-settled runs stay queued so hydration-dependent filters (`failureStep`) still converge progressively via `flushHydrationUpdates`, and an active `codebaseHash` filter hydrates the whole scope since membership needs every run's provenance (`needsEagerDetails` path, unchanged).

## Closed groups now release their bodies

Testing the viz-heavy scenario (open many runs' visualization galleries, then filter) surfaced a second accumulation path: closed tree groups kept their materialized bodies "until a full re-render reclaims it", so a long browsing session with no filter change grew card DOM — and pinned decoded images — without bound. Closing a group now drops its body immediately; reopening rebuilds it from the live run objects through the existing `renderLazyGroupBody` path, with descendant groups' expansion state restored via their retained `_openGroupKeys` entries. (Trade-off: reopening a closed group shows its cards' sections collapsed, same as after any re-render.)

## Measurements (real Chromium)

**Status-hydration fixture** (300 runs, ~25 KB traces; CDP heap after forced GC): narrowing to one dandiset in-page drops the post-GC JS heap **18.8 MB → 5.1 MB (−73%)** with zero additional network requests (re-reads served by the Cache API).

**Viz-heavy fixture** (60 runs × 6 large PNGs; 12 runs' galleries opened = 120 images loaded):

| Phase | Renderer RSS | JS heap | Connected DOM els / imgs |
|---|---|---|---|
| Viz open | 155 MB | 2.4 MB | 2164 / 120 |
| Group closed (no filter) — **new reclaim** | 159 MB | 2.4 MB | **264 / 0** |
| After in-page filter | 167 MB | 2.4 MB | 478 / 0 |
| After simulated memory pressure | 151 MB | 2.4 MB | 478 / 0 |
| After a **full page reload** (pre-PR behavior) | 137 MB | 2.3 MB | 478 / 0 |

Two takeaways worth stating explicitly. First, after a filter change (or group close) the page itself retains essentially nothing: connected DOM and JS heap return to baseline. Second, the renderer's RSS — what Chrome's task manager reports — stays elevated regardless, because Chromium keeps the encoded images in its per-renderer memory cache and allocators retain freed pages. That residue is **not page-owned**: it survives even a full page reload (137 MB vs the 130 MB cold baseline), is released by Chromium itself under memory pressure, and behaves identically before this PR (where every filter change *was* a full reload). No web API can force-evict it; what the page can do — and now does — is stop *owning* memory for content that's no longer on screen, so Chromium is free to discard the rest whenever it needs to.

## Testing

- 206 vitest tests pass (6 new: summary-stat link applied in place + blob memory cache cleared + popstate; out-of-scope payloads dropped/flags reset/settled status kept + no background re-read while out of scope + re-hydration on re-entry; Apply submit path; never-settled runs converging under a `failureStep` filter after a soft reset; view switches left to real navigation; group body released on close and rebuilt on reopen).
- `pre-commit` (prettier) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A2vvec1CkZwZxNVPhyfrYt